### PR TITLE
Updates to observation ids and the 'vary' input argument 

### DIFF
--- a/python/StateTL_calibration_control.txt
+++ b/python/StateTL_calibration_control.txt
@@ -1,6 +1,6 @@
 # This is a preliminary working file and will change as we add more functionality
 [Settings]
-calib_dir = test_updated_gains
+calib_dir = test_updated_gains_riverloop
 results_dir = results
 results_file = results.dat
 log_file = logfile.data
@@ -12,13 +12,13 @@ cpus = 20
 [Parameter Sensitivity]
 # <symbol> = <number of variations>
 T01 = 2
-T02 = 2
-SC01 = 2
-AW01 = 2
-AW02 = 2
-T03 = 2
-T04 = 2
+T02 = 1
+SC01 = 1
+AW01 = 1
+AW02 = 1
+T03 = 1
+T04 = 1
 
 [Latin Hypercube Sampling]
-sample_size = 20
+sample_size = 60
 

--- a/python/StateTL_calibration_inputdata.csv
+++ b/python/StateTL_calibration_inputdata.csv
@@ -1,17 +1,33 @@
 ﻿Div,WD,Reach,parameter,symbol,value,minimum,maximum,vary
-2,17,1,Transmissivity,T01,10000,10000,50000,True
-2,17,2,Transmissivity,T01,10000,10000,50000,True
-2,17,3,Transmissivity,T01,10000,10000,50000,True
-2,17,4,Transmissivity,T02,10000,5000,25000,True
-2,17,5,Transmissivity,T02,10000,5000,25000,True
-2,17,6,Transmissivity,T02,10000,5000,25000,True
-2,17,7,Transmissivity,T02,10000,5000,25000,True
-2,17,8,Transmissivity,T02,10000,5000,25000,True
+2,17,1,Transmissivity,T01,10000,5000,20000,True
+2,17,2,Transmissivity,T02,10000,5000,20000,True
+2,17,3,Transmissivity,T03,10000,5000,20000,True
+2,17,4,Transmissivity,T04,10000,5000,20000,True
+2,17,5,Transmissivity,T05,10000,5000,20000,True
+2,17,6,Transmissivity,T06,10000,5000,20000,True
+2,17,7,Transmissivity,T07,10000,5000,20000,True
+2,17,8,Transmissivity,T08,10000,5000,20000,True
 2,17,-1,Storage coefficient,SC01,0.15,0.1,0.2,True
-2,17,-1,Aquifer width,AW01,750,1000,3000,True
-2,17,6,Aquifer width,AW02,750,100,1000,True
-2,67,1,Transmissivity,T03,9000,100,15000,True
-2,67,2,Transmissivity,T03,9000,100,15000,True
-2,67,3,Transmissivity,T04,17500,10000,25000,True
-2,67,4,Transmissivity,T04,17500,10000,25000,True
-2,67,5,Transmissivity,T04,17500,10000,25000,True
+2,17,-1,Aquifer width,AW01,750,250,1500,True
+2,17,6,Aquifer width,AW02,750,250,1500,True
+2,17,-1,Dispersion-A,D_A,32,24,40,True
+2,17,-1,Dispersion-B,D_B,0.56,0.5,0.6,True
+2,17,2,Celerity-A,C_A2,0.6352,0.5,0.7,True
+2,17,2,Celerity-B,C_B2,0.2797,0.2,0.4,True
+2,17,3,Celerity-A,C_A3,0.6791,0.6,0.8,True
+2,17,3,Celerity-B,C_B3,0.2284,0.1,0.3,True
+2,17,4,Celerity-A,C_A4,0.5644,0.4,0.7,True
+2,17,4,Celerity-B,C_B4,0.2469,0.1,0.4,True
+2,17,5,Celerity-A,C_A5,0.7019,0.5,1.0,True
+2,17,5,Celerity-B,C_B5,0.2102,0.1,0.4,True
+2,17,6,Celerity-A,C_A6,0.4964,0.3,0.8,True
+2,17,6,Celerity-B,C_B6,0.2626,0.1,0.4,True
+2,17,7,Celerity-A,C_A7,1.1425,0.7,1.3,True
+2,17,8,Celerity-B,C_B7,0.1408,0.05,0.4,True
+2,17,8,Celerity-A,C_A8,1.1425,0.7,1.3,True
+2,17,8,Celerity-B,C_B8,0.1408,0.05,0.4,True
+2,67,1,Transmissivity,T09,9000,7000,11000,True
+2,67,2,Transmissivity,T10,9000,7000,11000,True
+2,67,3,Transmissivity,T11,17500,11000,24000,True
+2,67,4,Transmissivity,T12,17500,11000,24000,True
+2,67,5,Transmissivity,T13,17500,11000,24000,True


### PR DESCRIPTION
- Remove space in observation ids
- Bug Fix: Read vary parameters as Boolean not string